### PR TITLE
Enables building node-odbc with Node.js 20

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,6 @@
         '<!@(node -p "require(\'node-addon-api\').include")'
       ],
       'defines' : [
-        'NAPI_EXPERIMENTAL',
         'NAPI_VERSION=<(napi_build_version)'
       ],
       'conditions' : [
@@ -31,22 +30,22 @@
             [ 'target_arch=="arm64"', {
               'include_dirs': [
                 '/opt/homebrew/include'
-              ],  
+              ],
               'libraries' : [
                 '-L/opt/homebrew/lib',
                 '-lodbc'
-              ],  
+              ],
             }], ['target_arch=="x64"', {
               'include_dirs': [
                 '/usr/local/include',
-              ],  
+              ],
               'libraries' : [
                 '-L/usr/local/lib',
                 '-lodbc'
               ],
             }],
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
         }],
         [ 'OS == "freebsd"', {
           'include_dirs': [
@@ -56,7 +55,7 @@
             '-L/usr/local/lib',
             '-lodbc'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ]
         }],
         [ 'OS=="win"', {
           'sources' : [
@@ -66,7 +65,7 @@
           'libraries' : [
             '-lodbccp32.lib'
           ],
-          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'NAPI_EXPERIMENTAL', 'UNICODE' ]
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS', 'UNICODE' ]
         }],
         [ 'OS=="aix"', {
           'variables': {


### PR DESCRIPTION
## Background
This pull request removes the `NAPI_EXPERIMENTAL` flag, allowing `node-odbc` to be built with Node.js 20 (20.14.0). This improves compatibility and potentially fixes other build issues.

## Tested on:
* macOS 14.5
* Docker node:20-bookworm (arm64/v8 and amd64)
* Docker node:20-alpine3.19 (arm64/v8 and amd64)
